### PR TITLE
Update Newtonsoft.Json

### DIFF
--- a/src/Bandwidth.Net/Bandwidth.Net.csproj
+++ b/src/Bandwidth.Net/Bandwidth.Net.csproj
@@ -20,7 +20,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="10.0.2" />
+    <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
     <PackageReference Include="System.ValueTuple" Version="4.4.0" />
   </ItemGroup>
 


### PR DESCRIPTION
I'd like to use the latest `Newtonsoft.Json` without having to add bindings for Bandwidth (older version).