### PR TITLE
Avoid a NullReferenceException when the message location is null

### DIFF
--- a/src/Bandwidth.Net/Api/Message.cs
+++ b/src/Bandwidth.Net/Api/Message.cs
@@ -427,7 +427,7 @@ namespace Bandwidth.Net.Api
     /// <summary>
     /// Id of new message
     /// </summary>
-    public string Id => Location.Split('/').Last();
+    public string Id => Location?.Split('/').Last();
 
     /// <summary>
     /// Error information (if Result is Error)


### PR DESCRIPTION
This change avoids a thrown `NullReferenceException` due to an underlying dependency on the `Location` field when an error occurred while sending a message. This error occurred when mapping to an internal SMS message result representation, and it would be nice map without requiring a conditional for this field.